### PR TITLE
Remove duplicate factory

### DIFF
--- a/test/factories/foreman_datacenter_factories.rb
+++ b/test/factories/foreman_datacenter_factories.rb
@@ -1,5 +1,0 @@
-FactoryBot.define do
-  factory :host do
-    name 'foreman_datacenter'
-  end
-end


### PR DESCRIPTION
The host already has a factory in core.

Note that with this the tests do start, but the actual tests fail.