### PR TITLE
Remove deface dependency

### DIFF
--- a/foreman_datacenter.gemspec
+++ b/foreman_datacenter.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib,locale}/**/*'] + ['LICENSE', 'Rakefile', 'README.md']
   s.test_files = Dir['test/**/*']
 
-  s.add_dependency 'deface'
   s.add_dependency 'prawn', '~> 2.1'
   s.add_dependency 'rqrcode', '~> 0.10.1'
   s.add_development_dependency 'rubocop'

--- a/lib/foreman_datacenter/engine.rb
+++ b/lib/foreman_datacenter/engine.rb
@@ -1,5 +1,3 @@
-require 'deface'
-
 module ForemanDatacenter
   class Engine < ::Rails::Engine
     engine_name 'foreman_datacenter'


### PR DESCRIPTION
This is part of the plugin template but the gem isn't actually used.