### PR TITLE
Update devices_controller.rb

### DIFF
--- a/app/controllers/api/v2/foreman_datacenter/devices_controller.rb
+++ b/app/controllers/api/v2/foreman_datacenter/devices_controller.rb
@@ -47,7 +47,7 @@ module Api
 	param_group :device, :as => :create
 
 	def create
-	  @device = ::ForemanDatacenter::Device.new(device_params.merge(hosy_id: params[:host_id]))
+	  @device = ::ForemanDatacenter::Device.new(device_params.merge(host_id: params[:host_id]))
 	  process_response @device.save
 	end
 


### PR DESCRIPTION
Correcting typo on the spelling of host_id discovered when using the API to create new devices.
This misspelling causes the API to return a 500 Internal Error