### PR TITLE
Update device_interfaces_controller.rb

### DIFF
--- a/app/controllers/api/v2/foreman_datacenter/device_interfaces_controller.rb
+++ b/app/controllers/api/v2/foreman_datacenter/device_interfaces_controller.rb
@@ -38,7 +38,7 @@ module Api
 
 	def create
 	  @device_interface = ::ForemanDatacenter::DeviceInterface.new(device_interface_params)
-	  @device_interface.save
+	  process_response @device_interface.save
 	end
 
 	api :PUT, "/foreman_datacenter/device_interfaces/:id/", N_("Update a DeviceInterface")


### PR DESCRIPTION
Api v2 POSTs to device_interfaces not being saved.

The process_response routine was not being called inside the create method.