### PR TITLE
Add support to search comments from devices

### DIFF
--- a/app/controllers/foreman_datacenter/devices_controller.rb
+++ b/app/controllers/foreman_datacenter/devices_controller.rb
@@ -12,7 +12,7 @@ module ForemanDatacenter
                                          :sync_interfaces_with_host]
 
     def index
-      @devices = resource_base_search_and_page.includes(:device_role, :device_type, :site, :rack)
+      @devices = resource_base_search_and_page.includes(:device_role, :device_type, :site, :rack, :comments)
     end
 
     def show

--- a/app/models/foreman_datacenter/device.rb
+++ b/app/models/foreman_datacenter/device.rb
@@ -51,6 +51,7 @@ module ForemanDatacenter
     scoped_search in: :device_role, on: :name, complete_value: true, rename: :role
     scoped_search in: :device_type, on: :model, complete_value: true, rename: :type
     scoped_search in: :platform, on: :name, complete_value: true, rename: :platform
+    scoped_search in: :comments, on: :content, complete_value: true, rename: :comment
 
     delegate :site_id, to: :rack, allow_nil: true
     delegate :manufacturer_id, :is_console_server, :is_pdu, :is_network_device,


### PR DESCRIPTION
Added support to search comments from devices. Usable where you have comments at devices which describe essential data, i.e. clients telephone number so you can easily locate proper device