### PR TITLE
Fixes #28989 - Add description to plugin roles

### DIFF
--- a/lib/foreman_datacenter/engine.rb
+++ b/lib/foreman_datacenter/engine.rb
@@ -420,7 +420,7 @@ module ForemanDatacenter
           :edit_sites,
           :destroy_sites,
         ]
-        role "Datacenter Manager", MANAGER
+        role "Datacenter Manager", MANAGER, "TODO: Better description"
         add_all_permissions_to_default_roles
 
         sub_menu :top_menu, :datacenter, :after=> :infrastructure_menu, :icon => 'pficon pficon-enterprise' do

--- a/lib/foreman_datacenter/engine.rb
+++ b/lib/foreman_datacenter/engine.rb
@@ -420,7 +420,7 @@ module ForemanDatacenter
           :edit_sites,
           :destroy_sites,
         ]
-        role "Datacenter Manager", MANAGER, "TODO: Better description"
+        role "Datacenter Manager", MANAGER, "Role granting permissions to manage datacenters."
         add_all_permissions_to_default_roles
 
         sub_menu :top_menu, :datacenter, :after=> :infrastructure_menu, :icon => 'pficon pficon-enterprise' do


### PR DESCRIPTION
PR is part of  [Add default descriptions to all roles added from plugins](https://projects.theforeman.org/issues/28936) task.